### PR TITLE
add WO_ANKI env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ ln -s ~/Library/Application\ Support/Anki2/addons21/1045800357/user_files ~/Libr
 
 # After filling in `plugin/user_files` with the audio files, you can now run the server.
 # Ensure you have python 3.9 or above.
-python3 run_server.py
+WO_ANKI=1 python3 run_server.py
 ```
 
 ## Install from Source

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ cd local-audio-yomichan
 # You must fill `plugin/user_files` with the audio files, like with step 3 of the main instructions.
 # You can run one of the following OS-specific commands:
 mklink /d %LOCALAPPDATA%/local-audio-yomichan %APPDATA%/Anki2/addons21/1045800357/user_files # Windows (requires elavated priviledges)
-ln -s ~/.local/share/Anki2/addons21/1045800357/user_files ~/local/share/local-audio-yomichan # Linux
+ln -s ~/.local/share/Anki2/addons21/1045800357/user_files ~/.local/share/local-audio-yomichan # Linux
 ln -s ~/Library/Application\ Support/Anki2/addons21/1045800357/user_files ~/Library/Application\ Support/local-audio-yomichan # MacOS
 
 # After filling in `plugin/user_files` with the audio files, you can now run the server.

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -6,6 +6,36 @@ from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Optional
 from dataclasses import dataclass
+from enum import Enum, auto
+
+class Environment(Enum):
+    ANKI = auto()
+    WINDOWS = auto()
+    LINUX = auto()
+    DARWIN = auto()
+
+    @classmethod
+    def check(cls):
+
+        VAR_NAME = "WO_ANKI"
+
+        # check if the env var WO_ANKI is set
+        if os.environ.get(VAR_NAME, "").strip().lower() in ("1", "true"):
+            sys_platform = platform.system()
+            if sys_platform == "Windows":
+                return cls.WINDOWS
+            elif sys_platform == "Linux":
+                return cls.LINUX
+            elif sys_platform == "Darwin":
+                return cls.DARWIN
+            else:
+                raise Exception(f"Unknown platform: {sys_platform}")
+        elif importlib.util.find_spec("aqt"):
+            return cls.ANKI
+        else:
+            raise Exception(f"Could not determine environment, set the environment variable {VAR_NAME} if you are running without Anki.")
+
+
 
 from .consts import APP_NAME, DB_FILE_NAME, ANDROID_DB_FILE_NAME, LATEST_VERSION_FILE_NAME
 
@@ -75,13 +105,15 @@ def get_data_dir():
     """
     returns the native, platform-specific directory for the application data directory
     """
-    if importlib.util.find_spec("aqt"):
+    env = Environment.check()
+
+    if env == Environment.ANKI:
         return get_anki_data_dir()
-    elif platform.system() == "Windows":
+    elif env == Environment.WINDOWS:
         return get_win_data_dir()
-    elif platform.system() == "Linux":
+    elif env == Environment.LINUX:
         return get_linux_data_dir()
-    elif platform.system() == "Darwin":
+    elif env == Environment.DARWIN:
         return get_mac_data_dir()
     else:
         return get_anki_data_dir()
@@ -103,13 +135,15 @@ def get_config_dir():
     """
     returns the native, platform-specific directory for the application config directory
     """
-    if importlib.util.find_spec("aqt"):
+    env = Environment.check()
+
+    if env == Environment.ANKI:
         return get_anki_config_dir()
-    elif platform.system() == "Windows":
+    elif env == Environment.WINDOWS:
         return get_win_config_dir()
-    elif platform.system() == "Linux":
+    elif env == Environment.LINUX:
         return get_linux_config_dir()
-    elif platform.system() == "Darwin":
+    elif env == Environment.DARWIN:
         return get_mac_config_dir()
     else:
         return get_anki_config_dir()


### PR DESCRIPTION
First there was a typo in the `Running without Anki` session in the Readme for linux systems. It's `~/.local/` instead of `~/local` (as indicated in the code and as XDG default)

Second... I was trying to run it without anki and weirdly encountered errors as it seems to have found the wrong directory:

```
> python run_server.py
Initializing database. This make take a while...
(init_db) Adding entries from nhk16...
(make_nhk16_table) Cannot find entries file: /home/maa/Projects/local-audio-yomichan/plugin/user_files/nhk16_files/entries.json
(init_db) Adding entries from shinmeikai8...
(AJTJapaneseSource) Cannot find entries file: /home/maa/Projects/local-audio-yomichan/plugin/user_files/shinmeikai8_files/index.json
(init_db) Adding entries from forvo...
(init_db) Adding entries from jpod...
(init_db) Adding entries from jpod_alternate...
(init_db) Filling out JMdict forms...
Finished initializing database!
Running local audio server in debug mode...
```

I realized the detection logic is flawed, as I somehow have anki's `aqt` package installed as my system package, which is carried over even when I used `python -m venv ./venv` to create a virtual env for this repo. So the code would always think I'm inside anki and use the wrong directory.

I think introducing a seperate env var `WO_ANKI` is a good solution (open to better names). It's won't affect the current plugin users. And it won't affect those who already got it working standalone either because it means they don't have aqt installed. 

