### PR TITLE
Fix: Resolve Slow `localhost` Resolution on Windows by Using `127.0.0.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ There is currently no way of using this on AnkiMobile (iOS).
     * Set the first source to be `Custom URL (JSON)`.
     * Under the first source, set the `URL` field to:
         ```
-        http://localhost:5050/?term={term}&reading={reading}
+        http://127.0.0.1:5050/?term={term}&reading={reading}
         ```
     * If you have other sources, feel free to re-add them under the first source.
 
@@ -244,7 +244,7 @@ standard Yomitan sources and this local audio server.
 These are additional instructions and tips if something doesn't work as expected.
 
 *   Ensure the local audio server is actually running.
-    You can do this by visiting [http://localhost:5050](http://localhost:5050).
+    You can do this by visiting [http://127.0.0.1:5050](http://127.0.0.1:5050).
     If it says "Local Audio Server (version)", then the server is up and running!
 
 *   Make sure the database was properly generated.
@@ -283,7 +283,7 @@ These are additional instructions and tips if something doesn't work as expected
         <summary>JPod, NHK16, Shinmeikai8, Forvo (the original default order)</summary>
 
         ```
-        http://localhost:5050/?term={term}&reading={reading}&sources=jpod,nhk16,shinmeikai8,forvo
+        http://127.0.0.1:5050/?term={term}&reading={reading}&sources=jpod,nhk16,shinmeikai8,forvo
         ```
 
         </details>
@@ -292,7 +292,7 @@ These are additional instructions and tips if something doesn't work as expected
         <summary>NHK16, Shinmeikai8, Forvo (JPod will never be fetched!)</summary>
 
         ```
-        http://localhost:5050/?term={term}&reading={reading}&sources=nhk16,shinmeikai8,forvo
+        http://127.0.0.1:5050/?term={term}&reading={reading}&sources=nhk16,shinmeikai8,forvo
         ```
 
         </details>
@@ -301,7 +301,7 @@ These are additional instructions and tips if something doesn't work as expected
 
     For example, the following will get Forvo audio in the priority of strawberrybrown, then akitomo. All other users **will not be included in the search**.
     ```
-    http://localhost:5050/?term={term}&reading={reading}&user=strawberrybrown,akitomo
+    http://127.0.0.1:5050/?term={term}&reading={reading}&user=strawberrybrown,akitomo
     ```
 
     <details>
@@ -472,7 +472,7 @@ Huge thanks to everyone who made it happen:
     5. Restart Anki, and then regenerate the Local Audio Database (`Tools` →  `Local Audio Server` →  `Regenerate database`)
     6. Change your custom URL (JSON) value to the following:
         ```
-        http://localhost:5050/?term={term}&reading={reading}
+        http://127.0.0.1:5050/?term={term}&reading={reading}
         ```
         This URL removes the `sources` parameter, so sources can be added without having to
         change the URL in the future. However, please note that the **default source order has changed**

--- a/plugin/consts.py
+++ b/plugin/consts.py
@@ -1,7 +1,7 @@
 from typing import Final
 
 APP_NAME: Final = "local-audio-yomichan"
-HOSTNAME: Final = "localhost"
+HOSTNAME: Final = "127.0.0.1"
 PORT: Final = 5050
 DB_FILE_NAME: Final = "entries.db"
 ANDROID_DB_FILE_NAME: Final = "android.db"

--- a/tools/laudio.py
+++ b/tools/laudio.py
@@ -60,6 +60,8 @@ from typing import Any
 
 import requests
 
+from plugin.consts import HOSTNAME, PORT
+
 
 rx_PLAIN_FURIGANA = re.compile(r" ?([^ >]+?)\[(.+?)\]")
 
@@ -261,10 +263,10 @@ class AudioPlayer:
 
     def get_sources(self):
         if self.reading is None:
-            query_url = f"http://localhost:5050/?term={self.word}"
+            query_url = f"http://{HOSTNAME}:{PORT}/?term={self.word}"
         else:
             query_url = (
-                f"http://localhost:5050/?term={self.word}&reading={self.reading}"
+                f"http://{HOSTNAME}:{PORT}/?term={self.word}&reading={self.reading}"
             )
         r = requests.get(query_url)
         sources = r.json().get("audioSources")


### PR DESCRIPTION
This PR addresses performance issues caused by slow DNS resolution of `localhost` on Windows systems. As noted in [Anki Connect Issue #389](https://github.com/FooSoft/anki-connect/issues/389), Windows may introduce significant delays when resolving `localhost`, while using the explicit IP `127.0.0.1` avoids this overhead.

**Changes**:
- Replaced `HOSTNAME = "localhost"` with `HOSTNAME = "127.0.0.1"` to bypass DNS resolution delays.
- Updated hardcoded `localhost:5050` URLs to use the `{HOSTNAME}:{PORT}` template in `tools\laudio.py`.
- Revised `README.md` to reflect the use of `127.0.0.1` for clarity and consistency.

As a quick comparison:
- `localhost`:
```bash
$ for i in `seq 5`; do time curl localhost:5050; done
Local Audio Server v1.7.0
real    0m0.272s
user    0m0.000s
sys     0m0.015s
Local Audio Server v1.7.0
real    0m0.270s
user    0m0.015s
sys     0m0.015s
Local Audio Server v1.7.0
real    0m0.270s
user    0m0.000s
sys     0m0.031s
Local Audio Server v1.7.0
real    0m0.271s
user    0m0.000s
sys     0m0.015s
Local Audio Server v1.7.0
real    0m0.255s
user    0m0.000s
sys     0m0.000s
```
- `127.0.0.1`
```bash
$ for i in `seq 5`; do time curl 127.0.0.1:5050; done
Local Audio Server v1.7.0
real    0m0.048s
user    0m0.000s
sys     0m0.015s
Local Audio Server v1.7.0
real    0m0.029s
user    0m0.000s
sys     0m0.031s
Local Audio Server v1.7.0
real    0m0.049s
user    0m0.000s
sys     0m0.015s
Local Audio Server v1.7.0
real    0m0.029s
user    0m0.015s
sys     0m0.000s
Local Audio Server v1.7.0
real    0m0.049s
user    0m0.015s
sys     0m0.000s
```