### PR TITLE
Add 旺文社全訳古語辞典 audio source & fixed 'link.sh' for mac

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -3,11 +3,12 @@
 plugin_name=LocalAudioDev
 plugin_path_linux=~/.local/share/Anki2/addons21
 plugin_path_mac=~/Library/Application\ Support/Anki2/addons21
+expanded_mac_path="${plugin_path_mac/#\~/$HOME}"
 
 if [ -d "$plugin_path_linux" ]; then
     ln -s -f $(pwd)/plugin $plugin_path_linux/$plugin_name
 fi
 
-if [ -d "$plugin_path_mac" ]; then
-    ln -s -f $(pwd)/plugin $plugin_path_mac/$plugin_name
+if [ -d "$expanded_mac_path" ]; then
+    ln -s -f $(pwd)/plugin $expanded_mac_path/$plugin_name
 fi

--- a/plugin/config.py
+++ b/plugin/config.py
@@ -17,6 +17,7 @@ from .source.jpod import JPodAudioSource
 from .source.nhk16 import NHK16AudioSource
 from .source.forvo import ForvoAudioSource
 from .source.ajt_jp import AJTJapaneseSource
+from .source.ozk5 import OZK5AudioSource
 
 from .consts import CONFIG_FILE_NAME, DEFAULT_CONFIG_FILE_NAME
 from .util import get_config_dir, get_data_dir, get_program_root_dir
@@ -28,6 +29,7 @@ SOURCE_TYPES: Final[dict[str, Type[AudioSource]]] = {
     "nhk": NHK16AudioSource,
     "forvo": ForvoAudioSource,
     "ajt_jp": AJTJapaneseSource,
+    "ozk5": OZK5AudioSource
 }
 
 

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -29,6 +29,12 @@
       "id": "jpod_alternate",
       "path": "jpod_alternate_files",
       "display": "JPod101 Alt"
+    },
+    {
+      "type": "ozk5",
+      "id": "ozk5",
+      "path": "ozk5_files",
+      "display": "旺文社全訳古語辞典"
     }
   ]
 }

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -34,7 +34,7 @@
       "type": "ozk5",
       "id": "ozk5",
       "path": "ozk5_files",
-      "display": "旺文社全訳古語辞典"
+      "display": "OZK5 %s"
     }
   ]
 }

--- a/plugin/source/ozk5.py
+++ b/plugin/source/ozk5.py
@@ -1,0 +1,121 @@
+from __future__ import annotations  # for Python 3.7-3.9
+
+import json
+import sqlite3
+from typing import Optional, Final, TypedDict
+
+from .audio_source import AudioSource
+from ..jp_util import split_into_mora, hiragana_to_katakana
+
+
+"""
+This is based on the schema for OZK5 with entries, kanji_index, and kana_index:
+{
+  "meta": {
+    "name": "旺文社全訳古語辞典",
+    "year": 2025,
+    "version": 1,
+    "media_dir": "media"
+  },
+  "entries": [
+    {
+      "kanji": "亜",
+      "kana": "あ",
+      "audio_file": "audio.aac"
+    },
+    ...
+  ],
+  "kanji_index": {
+    "亜": [0],
+    ...
+  },
+  "kana_index": {
+    "あ": [0],
+    ...
+  }
+}
+"""
+
+
+class OZK5Data(TypedDict):
+    kanji: str
+    kana: str
+    audio_file: str
+    pitch_number: str
+
+
+class OZK5Meta(TypedDict):
+    name: str
+    year: int
+    version: int
+    media_dir: str
+
+
+class OZK5Index(TypedDict):
+    meta: OZK5Meta
+    entries: list[OZK5Data]
+    kanji_index: dict[str, list[int]]
+    kana_index: dict[str, list[int]]
+
+
+SQL: Final[
+    str
+] = "INSERT INTO entries (expression, reading, source, display, file) VALUES (?,?,?,?,?)"
+
+
+class OZK5AudioSource(AudioSource):
+    def get_display_text(self, entry: OZK5Data) -> Optional[str]:
+        """
+        displays as katakana with number and downstep, i.e. "ヨ＼ム [1]"
+        """
+        reading = entry.get("kana", None)
+        if reading is None:
+            return None
+        mora_list = split_into_mora(hiragana_to_katakana(reading))
+        try:
+            if entry["pitch_number"] == "?":
+                return None
+            pitch_accent = int(entry["pitch_number"])
+        except Exception:
+            # handle non-integer pitch numbers
+            print(f"({self.data.id}) pitch_number is not an integer: {entry}")
+            return None
+        if pitch_accent > 0:
+            mora_list.insert(pitch_accent, "＼")
+        return "".join(mora_list) + f" [{pitch_accent}]"
+
+    def add_entries(self, connection: sqlite3.Connection):
+        cur = connection.cursor()
+        index_file = self.get_media_dir_path().joinpath("index.json")
+
+        if not index_file.is_file():  # don't error if it simply doesn't exist
+            print(f"({self.__class__.__name__}) Cannot find entries file: {index_file}")
+            return
+
+        with open(index_file, encoding="utf-8") as f:
+            data: OZK5Index = json.load(f)
+            entries = data["entries"]
+            media_dir = data["meta"].get("media_dir", "media")
+
+            # Process all entries
+            for entry in entries:
+                expression = entry["kanji"] or entry["kana"]  # Use kana if no kanji
+                reading = entry["kana"]
+                audio_file = entry["audio_file"]
+                
+                fullpath = self.get_media_dir_path().joinpath(media_dir).joinpath(audio_file)
+                relpath = fullpath.relative_to(self.get_media_dir_path())
+                
+                if not fullpath.is_file():
+                    continue
+                
+                display = self.get_display_text(entry)
+                cur.execute(SQL, (expression, reading, self.data.id, display, str(relpath)))
+                
+                # If we have kanji, add another entry with kana as expression
+                # so it can be found by both kanji and kana lookups
+                if entry["kanji"] and entry["kanji"] != entry["kana"]:
+                    cur.execute(SQL, (reading, reading, self.data.id, display, str(relpath)))
+
+        cur.close()
+        connection.commit()

--- a/plugin/source/ozk5.py
+++ b/plugin/source/ozk5.py
@@ -65,24 +65,11 @@ SQL: Final[
 
 class OZK5AudioSource(AudioSource):
     def get_display_text(self, entry: OZK5Data) -> Optional[str]:
-        """
-        displays as katakana with number and downstep, i.e. "ヨ＼ム [1]"
-        """
+        """displays as katakana"""
         reading = entry.get("kana", None)
         if reading is None:
             return None
-        mora_list = split_into_mora(hiragana_to_katakana(reading))
-        try:
-            if entry["pitch_number"] == "?":
-                return None
-            pitch_accent = int(entry["pitch_number"])
-        except Exception:
-            # handle non-integer pitch numbers
-            print(f"({self.data.id}) pitch_number is not an integer: {entry}")
-            return None
-        if pitch_accent > 0:
-            mora_list.insert(pitch_accent, "＼")
-        return "".join(mora_list) + f" [{pitch_accent}]"
+        return "".join(split_into_mora(hiragana_to_katakana(reading)))
 
     def add_entries(self, connection: sqlite3.Connection):
         cur = connection.cursor()


### PR DESCRIPTION
# Add 旺文社全訳古語辞典 Audio Source

I have the audio from oubunshas kogo dict that im also converting to yomitan format rn. It has a bunch of audio for older japanese. There's audio for some poem entries. 

## Changes
- Added a new audio source type to handle the index for Oubunsha
- modified 'link.sh' to work on mac