### PR TITLE
 Enable CORS for all endpoints to support web-based clients

### DIFF
--- a/plugin/server.py
+++ b/plugin/server.py
@@ -49,19 +49,26 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         """Make log_message do nothing."""
         pass
 
+    def send_cors_response(self, code):
+        """Send response with CORS headers."""
+        self.send_response(code)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+
     def get_audio(self, media_dir, file_path):
         audio_file = media_dir.joinpath(file_path)
         if not audio_file.is_file():
-            self.send_response(400)
+            self.send_cors_response(400)
             return
 
         mime_type = LocalAudioHandler.SUFFIX_TO_MIME_TYPE.get(audio_file.suffix, None)
         if mime_type is None:
-            self.send_response(400)
+            self.send_cors_response(400)
             return
         self.send_response(200)
         self.send_header("Content-type", mime_type)
         self.send_header("Content-length", str(os.stat(audio_file).st_size))
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
 
         with open(audio_file, "rb") as fh:
@@ -75,10 +82,11 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
 
         mime_type = LocalAudioHandler.SUFFIX_TO_MIME_TYPE.get(audio_file.suffix, None)
         if mime_type is None:
-            self.send_response(400)
+            self.send_cors_response(400)
             return
         self.send_response(200)
         self.send_header("Content-type", mime_type)
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
 
         android_db_path = get_android_db_file()
@@ -91,7 +99,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
                 sql, {"file": file_path, "source": source}
             ).fetchone()
             if row is None:
-                self.send_response(400)
+                self.send_cors_response(400)
                 return
 
             data = row[0]
@@ -140,6 +148,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-type", "text/plain; charset=UTF-8")
         self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(payload)
 
@@ -157,7 +166,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
 
         if full_path.strip() == "/favicon.ico":
             # skip entirely
-            self.send_response(400)
+            self.send_cors_response(400)
             return
 
         path_parts = full_path.split("/", 2)
@@ -170,7 +179,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
 
         qcomps = self.parse_query_components()
         if not qcomps:
-            self.send_response(400)
+            self.send_cors_response(400)
             return
 
         audio_sources_json_list = []
@@ -205,6 +214,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-type", "application/json")
         self.send_header("Content-length", str(len(payload)))
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         try:
             self.wfile.write(payload)


### PR DESCRIPTION
## Description
  This PR adds CORS (Cross-Origin Resource Sharing) headers to all server endpoints, allowing
  web applications from any origin to access the local audio server.

 ## Background
  I encountered this issue while developing a local web app that needs to search for audio
  files using local-yomitan. Even when serving my web app from localhost, browsers block the
  requests due to CORS policy. I think this would be a common problem for developers building web-based tools
   that need to integrate with the local audio server.

  ## Changes
  - Added `Access-Control-Allow-Origin: *` header to all responses
  - Created `send_cors_response()` helper method for consistent error responses with CORS
  - Updated all endpoints to include CORS headers:
    - Version endpoint (`/`)
    - Audio file serving (`/{source}/{file}`)
    - JSON API endpoint (query parameters)
    - All error responses (400 status)

  ## Motivation
  The local audio server is a read-only service that provides Japanese audio pronunciation
  files. Adding CORS support enables:
  - Local web applications (even those running on localhost) to access the audio server
  - Web-based Japanese learning applications to fetch audio
  - Browser extensions and web apps to integrate with the server
  (I have no clue how yomitan extension is able to not get cors blocked...)
  - Development of new tools that leverage this audio database

  Since the server:
  - Only serves public audio data
  - Has no authentication or sensitive operations
  - Is designed for local use
  - Cannot modify any data

  There are no security concerns with allowing cross-origin access. This change makes the
  server more developer-friendly without compromising security.

  ## Testing
  - Confirmed web apps on localhost can now successfully fetch audio
  - Existing functionality remains unchanged