### PR TITLE
Fix reading of JMDict forms

### DIFF
--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -255,7 +255,7 @@ def backfill_jmdict_forms_rows(conn: sqlite3.Connection, group: ExpressionGroup,
     group_reading = group["reading"]
     for expression in group["expressions"]:
         kanji = expression["kanji"]
-        reading = expression.get("reading", group_reading)
+        reading = expression.get("override_reading", group_reading)
         meta_list.append(ExpressionMeta(kanji, reading))
 
     # this could be done slightly more efficiently with a group query, but


### PR DESCRIPTION
The jmdict_forms.json has a group "reading" field and if the reading needs to be overwritten, the override_reading field is used. Currently, some kana only entries won't ever be used because the expression and reading fields are different, for example:
<img width="732" height="161" alt="dbeaver_beMA57gnpk" src="https://github.com/user-attachments/assets/54055757-84e4-4809-ad58-67c13d9a3ecd" />
With this change, these kana only entries will have the same expression and reading:
<img width="731" height="160" alt="dbeaver_s7fk5VEjcW" src="https://github.com/user-attachments/assets/3d0cdd99-bd2d-483a-8596-0c7ff0e8f488" />