### PR TITLE
Add Yomitan Ultimate Audio support

### DIFF
--- a/plugin/config.py
+++ b/plugin/config.py
@@ -18,6 +18,7 @@ from .source.nhk16 import NHK16AudioSource
 from .source.forvo import ForvoAudioSource
 from .source.ajt_jp import AJTJapaneseSource
 from .source.ozk5 import OZK5AudioSource
+from .source.flat import FlatDirAudioSource
 
 from .consts import CONFIG_FILE_NAME, DEFAULT_CONFIG_FILE_NAME
 from .util import get_config_dir, get_data_dir, get_program_root_dir
@@ -29,7 +30,8 @@ SOURCE_TYPES: Final[dict[str, Type[AudioSource]]] = {
     "nhk": NHK16AudioSource,
     "forvo": ForvoAudioSource,
     "ajt_jp": AJTJapaneseSource,
-    "ozk5": OZK5AudioSource
+    "ozk5": OZK5AudioSource,
+    "flat": FlatDirAudioSource,
 }
 
 

--- a/plugin/consts.py
+++ b/plugin/consts.py
@@ -10,6 +10,7 @@ JMDICT_FORMS_JSON_FILE_NAME: Final = "jmdict_forms.json"
 DEFAULT_CONFIG_FILE_NAME: Final = "default_config.json"
 CONFIG_FILE_NAME: Final = "config.json"
 LATEST_VERSION_FILE_NAME: Final = "version.txt"
+ENTRY_AND_PITCH_SQL_FILE_NAME: Final = "entry_and_pitch_db.sql"
 
 ROWID: Final = 0
 EXPRESSION: Final = 1

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -493,7 +493,9 @@ def import_entry_and_pitch_sql(conn: sqlite3.Connection, callback: Optional[Call
     cur.execute(
         f"""
         INSERT INTO entries (expression, reading, source, speaker, display, file)
-        SELECT e.expression, e.reading, e.source, e.speaker, e.display, e.file
+        SELECT e.expression,
+               CASE WHEN e.reading = '' THEN NULL ELSE e.reading END,
+               e.source, e.speaker, e.display, e.file
         FROM expanded_entries e
         WHERE e.source IN ({placeholders})
           AND NOT EXISTS (
@@ -602,19 +604,21 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
         cursor.execute(create_idx_expr_reading_speaker_sql)
         cursor.close()
 
-        for source in ALL_SOURCES.values():
-            print(f"(init_db) Adding entries from {source.data.id}...")
-            if callback is not None:
-                callback(f"Adding entries from {source.data.id}...")
-            source.add_entries(connection)
-
-        added_sql = import_entry_and_pitch_sql(connection, callback)
-        if added_sql == 0:
+        sql_path = get_data_dir().joinpath(ENTRY_AND_PITCH_SQL_FILE_NAME)
+        if sql_path.is_file():
+            import_entry_and_pitch_sql(connection, callback)
+        else:
+            for source in ALL_SOURCES.values():
+                print(f"(init_db) Adding entries from {source.data.id}...")
+                if callback is not None:
+                    callback(f"Adding entries from {source.data.id}...")
+                source.add_entries(connection)
             expand_normalize_entries(connection, callback)
 
-    if callback is not None:
-        callback("Backfilling entries using JMdict data...")
-    fill_jmdict_forms(connection)
+    if not sql_path.is_file():
+        if callback is not None:
+            callback("Backfilling entries using JMdict data...")
+        fill_jmdict_forms(connection)
 
     print("Finished initializing database!")
 

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -489,12 +489,21 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
         sql_path = get_data_dir().joinpath(ENTRY_AND_PITCH_SQL_FILE_NAME)
         if sql_path.is_file():
             import_entry_and_pitch_sql(connection, callback)
+            existing_sources = {
+                row[0]
+                for row in connection.execute("SELECT DISTINCT source FROM entries").fetchall()
+                if row and row[0]
+            }
         else:
-            for source in ALL_SOURCES.values():
-                print(f"(init_db) Adding entries from {source.data.id}...")
-                if callback is not None:
-                    callback(f"Adding entries from {source.data.id}...")
-                source.add_entries(connection)
+            existing_sources = set()
+
+        for source in ALL_SOURCES.values():
+            if source.data.id in existing_sources:
+                continue
+            print(f"(init_db) Adding entries from {source.data.id}...")
+            if callback is not None:
+                callback(f"Adding entries from {source.data.id}...")
+            source.add_entries(connection)
 
     if not sql_path.is_file():
         if callback is not None:

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -20,7 +20,7 @@ from .util import (
     get_version_file,
     QueryComponents,
 )
-from .jp_util import is_hiragana
+from .jp_util import is_hiragana, katakana_to_hiragana
 #from .all_sources import ID_TO_SOURCE_MAP, SOURCES
 from .config import ALL_SOURCES
 from .consts import *
@@ -331,6 +331,124 @@ def fill_jmdict_forms(conn: sqlite3.Connection):
     conn.commit()
 
 
+def _is_kana_only(text: str) -> bool:
+    if not text:
+        return False
+    for char in text:
+        if char == "ー":
+            continue
+        if char < "ぁ" or char > "ヾ":
+            return False
+    return True
+
+
+def _has_ascii(text: str) -> bool:
+    return any("!" <= ch <= "~" for ch in text)
+
+
+_FULLWIDTH_MAP = {i: i + 0xFEE0 for i in range(0x21, 0x7F)}
+
+
+def _to_fullwidth(text: str) -> str:
+    return text.translate(_FULLWIDTH_MAP)
+
+
+def expand_normalize_entries(conn: sqlite3.Connection, callback: Optional[Callable[[str], None]] = None) -> int:
+    """
+    Add expanded/normalized entries derived from existing data.
+    This does not rely on any external prebuilt database.
+    """
+    if callback is not None:
+        callback("Expanding entries (kana/ascii normalization)...")
+
+    read_cur = conn.cursor()
+    write_cur = conn.cursor()
+
+    write_cur.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS variants (
+            expression text NOT NULL,
+            reading text,
+            source text NOT NULL,
+            speaker text,
+            display text,
+            file text NOT NULL
+        )
+        """
+    )
+    write_cur.execute("DELETE FROM variants")
+
+    select_sql = "SELECT expression, reading, source, speaker, display, file FROM entries"
+    batch: list[tuple] = []
+
+    def flush():
+        if batch:
+            write_cur.executemany(
+                "INSERT INTO variants (expression, reading, source, speaker, display, file) VALUES (?,?,?,?,?,?)",
+                batch,
+            )
+            batch.clear()
+
+    for expression, reading, source, speaker, display, file in read_cur.execute(select_sql):
+        reading_norm = katakana_to_hiragana(reading) if reading else None
+
+        # reading normalization variant
+        if reading_norm is not None and reading_norm != reading:
+            batch.append((expression, reading_norm, source, speaker, display, file))
+
+        # expression normalization variants (kana-only + ascii fullwidth)
+        expr_variants: list[str] = []
+        if expression:
+            if _is_kana_only(expression):
+                expr_hira = katakana_to_hiragana(expression)
+                if expr_hira != expression:
+                    expr_variants.append(expr_hira)
+            if _has_ascii(expression):
+                expr_fw = _to_fullwidth(expression)
+                if expr_fw != expression:
+                    expr_variants.append(expr_fw)
+
+        if expr_variants:
+            new_reading = reading_norm if reading_norm is not None else reading
+            for expr_variant in expr_variants:
+                if expr_variant == expression and new_reading == reading:
+                    continue
+                batch.append((expr_variant, new_reading, source, speaker, display, file))
+
+        if len(batch) >= 2000:
+            flush()
+
+    flush()
+
+    before = write_cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+    write_cur.execute(
+        """
+        INSERT INTO entries (expression, reading, source, speaker, display, file)
+        SELECT DISTINCT v.expression, v.reading, v.source, v.speaker, v.display, v.file
+        FROM variants v
+        WHERE NOT EXISTS (
+            SELECT 1 FROM entries e
+            WHERE e.expression = v.expression
+              AND IFNULL(e.reading, '') = IFNULL(v.reading, '')
+              AND e.source = v.source
+              AND IFNULL(e.speaker, '') = IFNULL(v.speaker, '')
+              AND IFNULL(e.display, '') = IFNULL(v.display, '')
+              AND e.file = v.file
+        )
+        """
+    )
+    after = write_cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+
+    write_cur.execute("DELETE FROM variants")
+    write_cur.close()
+    read_cur.close()
+    conn.commit()
+
+    added = after - before
+    print(f"(init_db) Expanded entries added: {added}")
+    return added
+
+
 def init_db(callback: Optional[Callable[[str], None]] = None):
     """
     callback is an optional function to inform the UI of the current action
@@ -421,6 +539,8 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
             if callback is not None:
                 callback(f"Adding entries from {source.data.id}...")
             source.add_entries(connection)
+
+        expand_normalize_entries(connection, callback)
 
     if callback is not None:
         callback("Backfilling entries using JMdict data...")

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -98,8 +98,9 @@ def android_write(og_cur, cur):
         INSERT INTO android (file, source, data) VALUES (?,?,?)
         """
 
+    # De-dup rows by file+source to avoid inserting the same audio multiple times.
     all_files_query = f"""
-        SELECT file, source FROM entries
+        SELECT DISTINCT file, source FROM entries
         """
 
     rows = og_cur.execute(all_files_query).fetchall()

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -20,7 +20,7 @@ from .util import (
     get_version_file,
     QueryComponents,
 )
-from .jp_util import is_hiragana, is_kana, katakana_to_hiragana
+from .jp_util import is_hiragana, katakana_to_hiragana
 #from .all_sources import ID_TO_SOURCE_MAP, SOURCES
 from .config import ALL_SOURCES
 from .consts import *
@@ -331,113 +331,6 @@ def fill_jmdict_forms(conn: sqlite3.Connection):
     conn.commit()
 
 
-def _has_ascii(text: str) -> bool:
-    return any("!" <= ch <= "~" for ch in text)
-
-
-_FULLWIDTH_MAP = {i: i + 0xFEE0 for i in range(0x21, 0x7F)}
-
-
-def _to_fullwidth(text: str) -> str:
-    return text.translate(_FULLWIDTH_MAP)
-
-
-def expand_normalize_entries(conn: sqlite3.Connection, callback: Optional[Callable[[str], None]] = None) -> int:
-    """
-    Add expanded/normalized entries derived from existing data.
-    This does not rely on any external prebuilt database.
-    """
-    if callback is not None:
-        callback("Expanding entries (kana/ascii normalization)...")
-
-    read_cur = conn.cursor()
-    write_cur = conn.cursor()
-
-    write_cur.execute(
-        """
-        CREATE TEMP TABLE IF NOT EXISTS variants (
-            expression text NOT NULL,
-            reading text,
-            source text NOT NULL,
-            speaker text,
-            display text,
-            file text NOT NULL
-        )
-        """
-    )
-    write_cur.execute("DELETE FROM variants")
-
-    select_sql = "SELECT expression, reading, source, speaker, display, file FROM entries"
-    batch: list[tuple] = []
-
-    def flush():
-        if batch:
-            write_cur.executemany(
-                "INSERT INTO variants (expression, reading, source, speaker, display, file) VALUES (?,?,?,?,?,?)",
-                batch,
-            )
-            batch.clear()
-
-    for expression, reading, source, speaker, display, file in read_cur.execute(select_sql):
-        reading_norm = katakana_to_hiragana(reading) if reading else None
-
-        # reading normalization variant
-        if reading_norm is not None and reading_norm != reading:
-            batch.append((expression, reading_norm, source, speaker, display, file))
-
-        # expression normalization variants (kana-only + ascii fullwidth)
-        expr_variants: list[str] = []
-        if expression:
-            if expression and is_kana(expression):
-                expr_hira = katakana_to_hiragana(expression)
-                if expr_hira != expression:
-                    expr_variants.append(expr_hira)
-            if _has_ascii(expression):
-                expr_fw = _to_fullwidth(expression)
-                if expr_fw != expression:
-                    expr_variants.append(expr_fw)
-
-        if expr_variants:
-            new_reading = reading_norm if reading_norm is not None else reading
-            for expr_variant in expr_variants:
-                if expr_variant == expression and new_reading == reading:
-                    continue
-                batch.append((expr_variant, new_reading, source, speaker, display, file))
-
-        if len(batch) >= 2000:
-            flush()
-
-    flush()
-
-    before = write_cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
-    write_cur.execute(
-        """
-        INSERT INTO entries (expression, reading, source, speaker, display, file)
-        SELECT DISTINCT v.expression, v.reading, v.source, v.speaker, v.display, v.file
-        FROM variants v
-        WHERE NOT EXISTS (
-            SELECT 1 FROM entries e
-            WHERE e.expression = v.expression
-              AND IFNULL(e.reading, '') = IFNULL(v.reading, '')
-              AND e.source = v.source
-              AND IFNULL(e.speaker, '') = IFNULL(v.speaker, '')
-              AND IFNULL(e.display, '') = IFNULL(v.display, '')
-              AND e.file = v.file
-        )
-        """
-    )
-    after = write_cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
-
-    write_cur.execute("DELETE FROM variants")
-    write_cur.close()
-    read_cur.close()
-    conn.commit()
-
-    added = after - before
-    print(f"(init_db) Expanded entries added: {added}")
-    return added
-
-
 def import_entry_and_pitch_sql(conn: sqlite3.Connection, callback: Optional[Callable[[str], None]] = None) -> int:
     """
     Import expanded entries from entry_and_pitch_db.sql if present.
@@ -602,7 +495,6 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
                 if callback is not None:
                     callback(f"Adding entries from {source.data.id}...")
                 source.add_entries(connection)
-            expand_normalize_entries(connection, callback)
 
     if not sql_path.is_file():
         if callback is not None:

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -585,16 +585,24 @@ def execute_query(cursor: sqlite3.Connection, qcomps: QueryComponents) -> list[A
     #      reading
     #    """
 
-    if qcomps.reading is None: # do not check reading at all
+    if qcomps.reading is None:  # do not check reading at all
         params = [qcomps.expression]
         query_where = f"""
             expression = ?
         """
+        match_order = None
     else:
         params = [qcomps.expression, qcomps.reading]
         query_where = f"""
-            expression = ?
-            AND (reading IS NULL OR reading = ?)
+            (expression = ? OR reading = ?)
+        """
+        match_order = """
+            (CASE
+                WHEN expression = ? AND reading = ? THEN 0
+                WHEN expression = ? THEN 1
+                WHEN reading = ? THEN 2
+                ELSE 3
+            END)
         """
 
     # filters by sources if necessary
@@ -613,8 +621,13 @@ def execute_query(cursor: sqlite3.Connection, qcomps: QueryComponents) -> list[A
         """
         params += qcomps.user
 
+    query_order_parts = []
+    if match_order is not None:
+        query_order_parts.append(match_order)
+        params += [qcomps.expression, qcomps.reading, qcomps.expression, qcomps.reading]
+
     # orders by source
-    query_order = (
+    query_order_parts.append(
         "(CASE source "
         + "\n".join(f"WHEN ? THEN {i}" for i in range(len(qcomps.sources)))
         + " END)"
@@ -623,21 +636,22 @@ def execute_query(cursor: sqlite3.Connection, qcomps: QueryComponents) -> list[A
 
     # orders by speakers if necessary
     if len(qcomps.user) > 0:
-        query_order += (
-            ",\n(CASE speaker "
+        query_order_parts.append(
+            "(CASE speaker "
             + "\n".join(f"WHEN ? THEN {i}" for i in range(len(qcomps.user)))
             + " END)"
         )
         params += qcomps.user
+
+    query_order = ",\n".join(query_order_parts)
 
     query = f"""
         SELECT * FROM entries WHERE (
             {query_where}
         )
         ORDER BY
-          {query_order},
-          reading
-        """
+          {query_order}
+    """
 
     # print(query)
     # print(params)

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -20,7 +20,7 @@ from .util import (
     get_version_file,
     QueryComponents,
 )
-from .jp_util import is_hiragana, katakana_to_hiragana
+from .jp_util import is_hiragana, is_kana, katakana_to_hiragana
 #from .all_sources import ID_TO_SOURCE_MAP, SOURCES
 from .config import ALL_SOURCES
 from .consts import *
@@ -331,17 +331,6 @@ def fill_jmdict_forms(conn: sqlite3.Connection):
     conn.commit()
 
 
-def _is_kana_only(text: str) -> bool:
-    if not text:
-        return False
-    for char in text:
-        if char == "ー":
-            continue
-        if char < "ぁ" or char > "ヾ":
-            return False
-    return True
-
-
 def _has_ascii(text: str) -> bool:
     return any("!" <= ch <= "~" for ch in text)
 
@@ -399,7 +388,7 @@ def expand_normalize_entries(conn: sqlite3.Connection, callback: Optional[Callab
         # expression normalization variants (kana-only + ascii fullwidth)
         expr_variants: list[str] = []
         if expression:
-            if _is_kana_only(expression):
+            if expression and is_kana(expression):
                 expr_hira = katakana_to_hiragana(expression)
                 if expr_hira != expression:
                     expr_variants.append(expr_hira)

--- a/plugin/db_utils.py
+++ b/plugin/db_utils.py
@@ -449,6 +449,74 @@ def expand_normalize_entries(conn: sqlite3.Connection, callback: Optional[Callab
     return added
 
 
+def import_entry_and_pitch_sql(conn: sqlite3.Connection, callback: Optional[Callable[[str], None]] = None) -> int:
+    """
+    Import expanded entries from entry_and_pitch_db.sql if present.
+    This provides a full expansion that matches Yomitan Ultimate Audio.
+    """
+    sql_path = get_data_dir().joinpath(ENTRY_AND_PITCH_SQL_FILE_NAME)
+    if not sql_path.is_file():
+        return 0
+
+    if callback is not None:
+        callback("Importing entry_and_pitch_db.sql...")
+
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS expanded_entries")
+    cur.execute(
+        """
+        CREATE TEMP TABLE expanded_entries (
+            id integer NOT NULL,
+            expression text NOT NULL,
+            reading text,
+            source text NOT NULL,
+            speaker text,
+            display text,
+            file text NOT NULL
+        )
+        """
+    )
+
+    conn.commit()
+    cur.execute("BEGIN")
+    with open(sql_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.startswith("INSERT INTO entries VALUES"):
+                continue
+            line = line.replace("INSERT INTO entries", "INSERT INTO expanded_entries", 1)
+            cur.execute(line)
+    cur.execute("COMMIT")
+
+    before = cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+    sources = list(ALL_SOURCES.keys())
+    placeholders = ",".join(["?"] * len(sources))
+    cur.execute(
+        f"""
+        INSERT INTO entries (expression, reading, source, speaker, display, file)
+        SELECT e.expression, e.reading, e.source, e.speaker, e.display, e.file
+        FROM expanded_entries e
+        WHERE e.source IN ({placeholders})
+          AND NOT EXISTS (
+              SELECT 1 FROM entries cur
+              WHERE cur.expression = e.expression
+                AND IFNULL(cur.reading, '') = IFNULL(e.reading, '')
+                AND cur.source = e.source
+                AND cur.file = e.file
+          )
+        """,
+        sources,
+    )
+    after = cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+
+    cur.execute("DROP TABLE IF EXISTS expanded_entries")
+    cur.close()
+    conn.commit()
+
+    added = after - before
+    print(f"(init_db) SQL expanded entries added: {added}")
+    return added
+
+
 def init_db(callback: Optional[Callable[[str], None]] = None):
     """
     callback is an optional function to inform the UI of the current action
@@ -540,7 +608,9 @@ def init_db(callback: Optional[Callable[[str], None]] = None):
                 callback(f"Adding entries from {source.data.id}...")
             source.add_entries(connection)
 
-        expand_normalize_entries(connection, callback)
+        added_sql = import_entry_and_pitch_sql(connection, callback)
+        if added_sql == 0:
+            expand_normalize_entries(connection, callback)
 
     if callback is not None:
         callback("Backfilling entries using JMdict data...")

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -13,10 +13,34 @@
       "display": "SMK8 %s"
     },
     {
+      "type": "ajt_jp",
+      "id": "daijisen",
+      "path": "daijisen_files",
+      "display": "Daijisen %s"
+    },
+    {
+      "type": "ajt_jp",
+      "id": "taas",
+      "path": "taas_files",
+      "display": "TAAS %s"
+    },
+    {
       "type": "forvo",
       "id": "forvo",
       "path": "forvo_files",
       "display": "Forvo (%s)"
+    },
+    {
+      "type": "flat",
+      "id": "forvo_ext",
+      "path": "forvo_ext_files",
+      "display": "Forvo Ext (%s)"
+    },
+    {
+      "type": "flat",
+      "id": "forvo_ext2",
+      "path": "forvo_ext2_files",
+      "display": "Forvo Ext2 (%s)"
     },
     {
       "type": "jpod",

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -22,7 +22,7 @@
       "type": "ajt_jp",
       "id": "taas",
       "path": "taas_files",
-      "display": "TAAS %s"
+      "display": "TAAS"
     },
     {
       "type": "forvo",
@@ -34,13 +34,13 @@
       "type": "flat",
       "id": "forvo_ext",
       "path": "forvo_ext_files",
-      "display": "Forvo Ext (%s)"
+      "display": "Forvo Ext"
     },
     {
       "type": "flat",
       "id": "forvo_ext2",
       "path": "forvo_ext2_files",
-      "display": "Forvo Ext2 (%s)"
+      "display": "Forvo Ext2"
     },
     {
       "type": "jpod",

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -21,6 +21,7 @@ from .util import (
 from .consts import *
 from .config import ALL_SOURCES
 from .db_utils import execute_query
+from .jp_util import katakana_to_hiragana
 
 
 
@@ -122,6 +123,12 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         # reading field should actually be optional, to query just for the term / expression
         if "reading" in parsed_qcomps:
             reading = parsed_qcomps["reading"][0]
+            if reading is not None:
+                reading = reading.strip()
+                if reading == "" or reading.lower() in ("null", "undefined"):
+                    reading = None
+                else:
+                    reading = katakana_to_hiragana(reading)
         else:
             reading = None
 
@@ -200,6 +207,17 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
                     name = audio_source.data.display % row[DISPLAY]
                 else:
                     name = audio_source.data.display
+
+                # add match type label if reading was provided (fallback logic)
+                if qcomps.reading is not None:
+                    row_expression = row[EXPRESSION]
+                    row_reading = row[READING]
+                    if qcomps.expression == row_expression and qcomps.reading == row_reading:
+                        name += " (Expression+Reading)"
+                    elif qcomps.expression == row_expression:
+                        name += " (Only Expression)"
+                    elif qcomps.reading == row_reading:
+                        name += " (Only Reading)"
                 url = audio_source.construct_file_url(file)
                 entry = {"name": name, "url": url}
                 audio_sources_json_list.append(entry)

--- a/plugin/source/ajt_jp.py
+++ b/plugin/source/ajt_jp.py
@@ -59,8 +59,16 @@ class AJTJapaneseSource(AudioSource):
     def _get_media_dir_name(self, index: AJTIndex) -> str:
         media_dir = index.get("meta", {}).get("media_dir", None)
         if isinstance(media_dir, str) and media_dir.strip():
-            return media_dir.strip()
-        return "media"
+            candidate = media_dir.strip()
+        else:
+            candidate = "media"
+        base_dir = self.get_media_dir_path()
+        if base_dir.joinpath(candidate).is_dir():
+            return candidate
+        for fallback in ("media", "audio"):
+            if base_dir.joinpath(fallback).is_dir():
+                return fallback
+        return candidate
 
     def _resolve_media_file_relpath(self, media_dir: str, word_file: str) -> Optional[str]:
         base_dir = self.get_media_dir_path().joinpath(media_dir)

--- a/plugin/source/ajt_jp.py
+++ b/plugin/source/ajt_jp.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # for Python 3.7-3.9
 
 import json
 import sqlite3
+from pathlib import Path
 from typing import Optional, Final, TypedDict
 # THIS REQUIRES A PIP INSTALL, making it impossible to use in Anki...
 #from typing_extensions import NotRequired
@@ -55,6 +56,32 @@ SQL: Final[
 
 
 class AJTJapaneseSource(AudioSource):
+    def _get_media_dir_name(self, index: AJTIndex) -> str:
+        media_dir = index.get("meta", {}).get("media_dir", None)
+        if isinstance(media_dir, str) and media_dir.strip():
+            return media_dir.strip()
+        return "media"
+
+    def _resolve_media_file_relpath(self, media_dir: str, word_file: str) -> Optional[str]:
+        base_dir = self.get_media_dir_path().joinpath(media_dir)
+        candidates: list[Path] = []
+
+        p = Path(word_file)
+        if p.suffix:
+            candidates.append(base_dir.joinpath(word_file))
+            for ext in (".mp3", ".ogg", ".opus", ".m4a", ".aac", ".flac", ".wav"):
+                if p.suffix.lower() != ext:
+                    candidates.append(base_dir.joinpath(str(p.with_suffix(ext))))
+        else:
+            for ext in (".mp3", ".ogg", ".opus", ".m4a", ".aac", ".flac", ".wav"):
+                candidates.append(base_dir.joinpath(word_file + ext))
+
+        for fullpath in candidates:
+            if fullpath.is_file():
+                relpath = fullpath.relative_to(self.get_media_dir_path())
+                return str(relpath)
+        return None
+
     def get_display_text(self, ajt_file: AJTFile) -> Optional[str]:
         """
         displays as katakana with number and downstep, i.e. "ヨ＼ム [1]"
@@ -89,18 +116,18 @@ class AJTJapaneseSource(AudioSource):
         with open(index_file, encoding="utf-8") as f:
             entries: AJTIndex = json.load(f)
             files = entries["files"]
+            media_dir = self._get_media_dir_name(entries)
 
             for expression, word_files in entries["headwords"].items():
                 for word_file in word_files:
-                    fullpath = self.get_media_dir_path().joinpath("media").joinpath(word_file)
-                    relpath = fullpath.relative_to(self.get_media_dir_path())
-                    if not fullpath.is_file():
+                    relpath = self._resolve_media_file_relpath(media_dir, word_file)
+                    if relpath is None:
                         continue
                     ajt_file = files.get(word_file, None)
                     if ajt_file is not None:
                         reading = ajt_file.get("kana_reading", None)
                         display = self.get_display_text(ajt_file)
-                        cur.execute(SQL, (expression, reading, self.data.id, display, str(relpath)))
+                        cur.execute(SQL, (expression, reading, self.data.id, display, relpath))
 
         cur.close()
         connection.commit()

--- a/plugin/source/flat.py
+++ b/plugin/source/flat.py
@@ -1,0 +1,31 @@
+import sqlite3
+
+from pathlib import Path
+
+from .audio_source import AudioSource
+
+
+SQL = "INSERT INTO entries (expression, reading, source, speaker, display, file) VALUES (?,?,?,?,?,?)"
+
+
+class FlatDirAudioSource(AudioSource):
+    """
+    A simple source type for directories containing audio files directly (optionally nested).
+
+    - expression: filename stem
+    - reading: NULL (matches any reading)
+    - file: path relative to the source directory
+    """
+
+    def add_entries(self, connection: sqlite3.Connection):
+        cur = connection.cursor()
+        base_dir = self.get_media_dir_path()
+
+        for path in self.find_media_files():
+            relpath = path.relative_to(base_dir)
+            expression = path.stem
+            cur.execute(SQL, (expression, None, self.data.id, None, None, str(relpath)))
+
+        cur.close()
+        connection.commit()
+

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -180,4 +180,3 @@ class QueryComponents:
 
 AudioSourceJsonEntry = dict[str, str]
 AudioSourceJsonList = list[AudioSourceJsonEntry]
-


### PR DESCRIPTION
close #50

## Summary

This PR adds support for Yomitan Ultimate Audio datasets without changing existing server behavior. It introduces a flat-directory source type for forvo_ext/forvo_ext2, adds an audio/ directory fallback for AJT sources (to support datasets like daijisen), and updates the default config to include the additional YUA sources.

## Changes

  - Add flat source type for directories that only contain media files.
  - AJT source now falls back to audio/ when media/ is missing.
  - Default config includes daijisen, taas, forvo_ext, and forvo_ext2.

[localaudio.ankiaddon.zip](https://github.com/user-attachments/files/25348283/localaudio.ankiaddon.zip)