### PR TITLE
feat: add multi-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ These are additional instructions and tips if something doesn't work as expected
 
         </details>
 
+* You can filter sources by language using `&language=`.
+
+    For example, the following will only fetch audio from sources configured for Japanese:
+    ```
+    http://127.0.0.1:5050/?term={term}&reading={reading}&language=ja
+    ```
+
+    Sources without a configured language are included as fallback.
+
 * For Forvo audio specifically, you can modify the priority of users by using `&user=`.
 
     For example, the following will get Forvo audio in the priority of strawberrybrown, then akitomo. All other users **will not be included in the search**.
@@ -321,6 +330,7 @@ If you want even more power, sources can be manually configured using a config f
 On top of changing the priority of sources and removing sources, you can do the following:
 - Specify a path for each source folder. You can use this to store audio files in a different drive.
 - Add entirely new audio sources
+- Configure languages for each source
 
 ### Config Setup
 

--- a/plugin/config.py
+++ b/plugin/config.py
@@ -7,6 +7,7 @@ Source schema:
 - id: string id used as the id in the "source" column, as well as the parameter in the url
 - path: string, path to the source files
 - display: string used to display in Yomitan. Uses %s for the "DISPLAY" column.
+- languages: list of strings, languages supported by the source. Defaults to [] if missing.
 """
 
 import json

--- a/plugin/config.py
+++ b/plugin/config.py
@@ -38,6 +38,7 @@ class JsonConfigSource(TypedDict):
     id: str
     path: str
     display: str
+    languages: list[str]  # optional, defaults to [] if missing
 
 
 class JsonConfig(TypedDict):
@@ -82,6 +83,7 @@ def get_all_sources() -> dict[str, AudioSource]:
         type = source_json["type"]
         path = source_json["path"]
         display = source_json["display"]
+        languages = source_json.get("languages", [])
 
         # checks for source_meta.json
         source_meta_path = get_data_dir() / path / "source_meta.json"
@@ -93,7 +95,7 @@ def get_all_sources() -> dict[str, AudioSource]:
                     type = meta_type
 
         AudioSourceClass = SOURCE_TYPES[type]
-        data = AudioSourceData(id, path, display)
+        data = AudioSourceData(id, path, display, languages)
         source = AudioSourceClass(data)
         sources[id] = source
     return sources

--- a/plugin/default_config.json
+++ b/plugin/default_config.json
@@ -4,37 +4,43 @@
       "type": "nhk",
       "id": "nhk16",
       "path": "nhk16_files",
-      "display": "NHK16 %s"
+      "display": "NHK16 %s",
+      "languages": ["ja"]
     },
     {
       "type": "ajt_jp",
       "id": "shinmeikai8",
       "path": "shinmeikai8_files",
-      "display": "SMK8 %s"
+      "display": "SMK8 %s",
+      "languages": ["ja"]
     },
     {
       "type": "forvo",
       "id": "forvo",
       "path": "forvo_files",
-      "display": "Forvo (%s)"
+      "display": "Forvo (%s)",
+      "languages": ["ja", "en", "zh", "ko"]
     },
     {
       "type": "jpod",
       "id": "jpod",
       "path": "jpod_files",
-      "display": "Jpod101"
+      "display": "Jpod101",
+      "languages": ["ja"]
     },
     {
       "type": "jpod",
       "id": "jpod_alternate",
       "path": "jpod_alternate_files",
-      "display": "JPod101 Alt"
+      "display": "JPod101 Alt",
+      "languages": ["ja"]
     },
     {
       "type": "ozk5",
       "id": "ozk5",
       "path": "ozk5_files",
-      "display": "OZK5 %s"
+      "display": "OZK5 %s",
+      "languages": ["ja"]
     }
   ]
 }

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -130,6 +130,16 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         else:
             sources = list(ALL_SOURCES.keys())
 
+        # narrow sources by language if the param is present
+        if "language" in parsed_qcomps:
+            lang = parsed_qcomps["language"][0]
+            # keep sources that declare this language, OR have no language set
+            sources = [
+                sid for sid in sources
+                if lang in ALL_SOURCES[sid].data.languages
+                or not ALL_SOURCES[sid].data.languages
+            ]
+
         if "user" in parsed_qcomps:
             user = [u.strip() for u in parsed_qcomps["user"][0].split(",")]
         else:

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -108,7 +108,7 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
             android_cursor.close()
 
     def parse_query_components(self) -> QueryComponents:
-        """Extract 'term', 'reading', 'sources', and 'user' query parameters"""
+        """Extract 'term', 'reading', 'sources', 'language', and 'user' query parameters"""
         parsed_qcomps = parse_qs(urlparse(self.path).query)
 
         if "term" in parsed_qcomps:

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -133,12 +133,16 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         # narrow sources by language if the param is present
         if "language" in parsed_qcomps:
             lang = parsed_qcomps["language"][0]
-            # keep sources that declare this language, OR have no language set
-            sources = [
-                sid for sid in sources
-                if lang in ALL_SOURCES[sid].data.languages
-                or not ALL_SOURCES[sid].data.languages
-            ]
+            # declared first, empty-language sources appended as fallback;
+            # sources declaring other languages are dropped
+            declared, unspecified = [], []
+            for sid in sources:
+                langs = ALL_SOURCES[sid].data.languages
+                if lang in langs:
+                    declared.append(sid)
+                elif not langs:
+                    unspecified.append(sid)
+            sources = declared + unspecified
 
         if "user" in parsed_qcomps:
             user = [u.strip() for u in parsed_qcomps["user"][0].split(",")]

--- a/plugin/source/audio_source.py
+++ b/plugin/source/audio_source.py
@@ -22,6 +22,7 @@ class AudioSourceData:
     id: Final[str]  # also the table name
     media_dir: Final[str]
     display: Final[str]
+    languages: Final[list[str]]  # empty list means "language not set"
 
 
 class AudioSource(ABC):


### PR DESCRIPTION
This PR adds multi-language support.
The server now accepts an optional `language` parameter (e.g., `language=ja`).

Example request:
`http://127.0.0.1:5050/?term={term}&reading={reading}&language=ja`

If the language parameter is not provided, the server will fall back to the default behavior.
Sources without a configured language are included as fallback.

Closes #31
